### PR TITLE
fixed bug when video duration is longer than hour

### DIFF
--- a/edx_crawler.py
+++ b/edx_crawler.py
@@ -579,7 +579,7 @@ def videolen(yt_link):
 	elif len(timeformat) == 2:
 		duration = int(timeformat[0])*60+int(timeformat[1])
 	else:
-		duration = int(timeformat[0])*3600+int(timeformat[1])*60+ timeformat[2]
+		duration = int(timeformat[0])*3600+int(timeformat[1])*60+ int(timeformat[2])
 	return duration
 
 def vtt2json(vttfile):


### PR DESCRIPTION
Just found a bug when extracting video duration longer than an hour.
